### PR TITLE
Bump the maven group across 2 directories with 4 updates

### DIFF
--- a/axiom-spring-boot-starter/pom.xml
+++ b/axiom-spring-boot-starter/pom.xml
@@ -25,7 +25,7 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-autoconfigure</artifactId>
-            <version>2.7.10</version>
+            <version>2.7.12</version>
         </dependency>
         
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
         <jackson.version>2.14.3</jackson.version>
         <guice.version>5.1.0</guice.version>
         <slf4j.version>1.7.36</slf4j.version>
-        <logback.version>1.2.11</logback.version>
+        <logback.version>1.2.13</logback.version>
         <junit.version>5.10.2</junit.version>
         <mockito.version>3.12.4</mockito.version>
         <assertj.version>3.18.0</assertj.version>
@@ -165,7 +165,7 @@
             <dependency>
                 <groupId>org.yaml</groupId>
                 <artifactId>snakeyaml</artifactId>
-                <version>1.33</version>
+                <version>2.0</version>
             </dependency>
             
             <!-- Maven Plugin Dependencies -->


### PR DESCRIPTION
Bumps the maven group with 2 updates in the / directory: [ch.qos.logback:logback-classic](https://github.com/qos-ch/logback) and [org.yaml:snakeyaml](https://bitbucket.org/snakeyaml/snakeyaml).
Bumps the maven group with 3 updates in the /axiom-spring-boot-starter directory: [ch.qos.logback:logback-classic](https://github.com/qos-ch/logback), [org.yaml:snakeyaml](https://bitbucket.org/snakeyaml/snakeyaml) and [org.springframework.boot:spring-boot-autoconfigure](https://github.com/spring-projects/spring-boot).


Updates `ch.qos.logback:logback-classic` from 1.2.11 to 1.2.13
- [Release notes](https://github.com/qos-ch/logback/releases)
- [Commits](https://github.com/qos-ch/logback/compare/v_1.2.11...v_1.2.13)

Updates `ch.qos.logback:logback-core` from 1.2.11 to 1.2.13
- [Release notes](https://github.com/qos-ch/logback/releases)
- [Commits](https://github.com/qos-ch/logback/compare/v_1.2.11...v_1.2.13)

Updates `org.yaml:snakeyaml` from 1.33 to 2.0
- [Commits](https://bitbucket.org/snakeyaml/snakeyaml/branches/compare/snakeyaml-2.0..snakeyaml-1.33)

Updates `ch.qos.logback:logback-classic` from 1.2.11 to 1.2.13
- [Release notes](https://github.com/qos-ch/logback/releases)
- [Commits](https://github.com/qos-ch/logback/compare/v_1.2.11...v_1.2.13)

Updates `ch.qos.logback:logback-core` from 1.2.11 to 1.2.13
- [Release notes](https://github.com/qos-ch/logback/releases)
- [Commits](https://github.com/qos-ch/logback/compare/v_1.2.11...v_1.2.13)

Updates `org.yaml:snakeyaml` from 1.33 to 2.0
- [Commits](https://bitbucket.org/snakeyaml/snakeyaml/branches/compare/snakeyaml-2.0..snakeyaml-1.33)

Updates `org.springframework.boot:spring-boot-autoconfigure` from 2.7.10 to 2.7.12
- [Release notes](https://github.com/spring-projects/spring-boot/releases)
- [Commits](https://github.com/spring-projects/spring-boot/compare/v2.7.10...v2.7.12)

---
updated-dependencies:
- dependency-name: ch.qos.logback:logback-classic dependency-version: 1.2.13 dependency-type: direct:production dependency-group: maven
- dependency-name: ch.qos.logback:logback-core dependency-version: 1.2.13 dependency-type: direct:production dependency-group: maven
- dependency-name: org.yaml:snakeyaml dependency-version: '2.0' dependency-type: direct:production dependency-group: maven
- dependency-name: ch.qos.logback:logback-classic dependency-version: 1.2.13 dependency-type: direct:production dependency-group: maven
- dependency-name: ch.qos.logback:logback-core dependency-version: 1.2.13 dependency-type: direct:production dependency-group: maven
- dependency-name: org.yaml:snakeyaml dependency-version: '2.0' dependency-type: direct:production dependency-group: maven
- dependency-name: org.springframework.boot:spring-boot-autoconfigure dependency-version: 2.7.12 dependency-type: direct:production dependency-group: maven ...